### PR TITLE
Add generated product concept, UX concept and domain glossary from Miro

### DIFF
--- a/docs/product/domain_glossary.adoc
+++ b/docs/product/domain_glossary.adoc
@@ -1,132 +1,240 @@
 = Domänenmodell und Glossar: {project-name}
-Vorname Nachname <email@domain.org>; Vorname2 Nachname2 <email2@domain.org>; Vorname3 Nachname3 <email3@domain.org>
+Jannik Thiele; Niels Wiesner; Quôc Dat Nguyên; Juan Ramiro Groh Fili; Johannes Meinck; Franz Rehschuh; Lennox Schmollny
 {localdatetime}
 include::../_includes/default-attributes.inc.adoc[]
-// Platzhalter für weitere Dokumenten-Attribute
 
-_Dieses Dokument beschreibt die wesentlichen fachlichen Begriffe und ihre  Beziehungen untereinander. Es bildet die gemeinsame Sprache des Teams und aller Stakeholder — unabhängig von technischen Umsetzungsentscheidungen.
-Alle Begriffe in User Stories, Personas und Gesprächen mit Stakeholdern sollten hier definiert sein._
+_Dieses Dokument beschreibt die wesentlichen fachlichen Begriffe und ihre Beziehungen untereinander. Es bildet die gemeinsame Sprache des Teams und aller Stakeholder — unabhängig von technischen Umsetzungsentscheidungen. Alle Begriffe in User Stories, Personas und Gesprächen mit Stakeholdern sollten hier definiert sein._
 
 ---
 
 == Glossar
 
-Alle *fachlichen* Begriffe und Abkürzungen werden hier alphabetisch definiert.
-Ziel ist eine einheitliche Sprache im gesamten Team.
-Technische Implementierungsdetails gehören nicht hierher!
-
 [cols="1,3,2", options="header"]
 |===
 | Begriff / Abkürzung | Definition | Synonyme / Abgrenzungen
 
-| Bestellung
-| Eine vom Nutzer ausgelöste Anforderung, ein oder mehrere Produkte zu erwerben.
-  Eine Bestellung durchläuft verschiedene Status (offen, bezahlt, versendet, abgeschlossen).
-| Auftrag; nicht zu verwechseln mit „Warenkorb" (noch nicht abgeschlossen)
+| Abo
+| Eine wiederkehrende Zahlungsvereinbarung zwischen einem Nutzer und einem Anbieter, bei der der Nutzer in regelmäßigen Abständen (monatlich, jährlich, etc.) einen Betrag zahlt und dafür Zugang zu einem Dienst oder Produkt erhält.
+| Abonnement, Subscription; nicht zu verwechseln mit Einmalkauf
+
+| Abomodell
+| Das Geschäftsmodell eines Anbieters, das auf wiederkehrenden Zahlungen statt Einmalkäufen basiert. Abomodelle umfassen Streaming-Dienste, Gym-Mitgliedschaften, Software-Lizenzen, Cloud-Speicher u. ä.
+| Subscription Model; abzugrenzen von Einzelkauf/Lizenz
+
+| Zahlungsbetrag
+| Der Betrag, den ein Nutzer pro Zahlungsintervall für ein Abo zahlt.
+| Beitrag, Preis, Kosten; abzugrenzen vom Gesamtbetrag (Summe aller Abos)
+
+| Zahlungsintervall
+| Der Zeitraum zwischen zwei aufeinanderfolgenden Abbuchungen eines Abos. Typische Werte: monatlich, vierteljährlich, jährlich.
+| Zahlungsrhythmus, Abrechnungszeitraum; Synonym: Zahlungsabstand
+
+| Zahlungsabstand
+| Synonym für Zahlungsintervall — der Abstand in Tagen/Monaten/Jahren zwischen zwei Zahlungen.
+| Zahlungsintervall
+
+| Kündigungsfrist
+| Der Zeitraum, innerhalb dessen ein Abo vor dem nächsten Verlängerungstermin gekündigt werden muss, um eine weitere Abbuchung zu vermeiden.
+| Notice Period; abzugrenzen vom Abschlussdatum oder der Laufzeit
+
+| Automatische Verlängerung
+| Eine Eigenschaft von Abos, bei der das Abonnement nach Ablauf der Laufzeit automatisch verlängert wird, sofern es nicht fristgerecht gekündigt wurde.
+| Auto-Renewal; Gegenteil: manuelle Verlängerung
+
+| Abschlussdatum
+| Das Datum, an dem ein Abo ursprünglich abgeschlossen bzw. begonnen wurde.
+| Startdatum, Vertragsbeginn; abzugrenzen vom Verlängerungsdatum
+
+| Vertragspartner
+| Das Unternehmen oder die Organisation, mit der der Nutzer das Abo-Vertragsverhältnis eingegangen ist (z. B. Netflix, Spotify, Gym XY).
+| Anbieter, Dienstleister
+
+| Abo-Details
+| Die Gesamtheit der relevanten Informationen zu einem Abo: Produktname, Vertragspartner, Zahlungsbetrag, Zahlungsintervall, Abschlussdatum, Kündigungsfrist, Kategorie, Notizen.
+| Abo-Informationen, Abo-Konditionen, Abo-Eigenschaften
+
+| Kategorie
+| Eine vom Nutzer zugewiesene oder automatisch erkannte Klassifikation eines Abos (z. B. Streaming, Sport, Musik, Software, privat, geschäftlich).
+| Tag, Label; ermöglicht Gruppierung und Filterung von Abos
+
+| Übersicht
+| Die Hauptansicht der App, die alle erfassten Abos strukturiert darstellt — mit Filtermöglichkeiten, Sortierung und Kennzahlen.
+| Dashboard, Abo-Liste; abzugrenzen von der Detailansicht eines einzelnen Abos
+
+| Kennzahl
+| Eine aggregierte Information über alle oder eine Gruppe von Abos, z. B. Gesamtkosten pro Monat, Anzahl aktiver Abos, Abos mit nahender Kündigungsfrist.
+| Metrik, KPI
+
+| Gesamtkosten
+| Die Summe aller aktiven Abo-Zahlungsbeträge pro Monat (oder anderes Intervall), ggf. gefiltert nach Kategorie.
+| Monatliche Gesamtausgaben; abzugrenzen von Jahreskosten (Hochrechnung)
+
+| Erinnerung
+| Eine vom System ausgelöste Benachrichtigung, die den Nutzer auf eine nahende Kündigungsfrist oder Verlängerung hinweist.
+| Notification, Alert; Gegenteil: keine Benachrichtigung
+
+| Kündigung
+| Der Vorgang, mit dem ein Nutzer ein Abo beendet. Kann direkt über die App (Weiterleitung zur Anbieter-Website, Generierung eines Kündigungsschreibens) oder manuell erfolgen.
+| Abokündigung, Vertragskündigung
+
+| Kündigungsschreiben
+| Ein formal korrektes Schreiben zur Kündigung eines Abos, das von der App generiert und dem Nutzer bereitgestellt wird.
+| Kündigungsbrief; muss Mindestanforderungen des Anbieters entsprechen
 
 | Nutzer
-| Eine Person, die das System aktiv verwendet. Nutzer müssen registriert und eingeloggt
-  sein, um Bestellungen aufzugeben.
+| Eine Person, die SubscriptionGuard aktiv verwendet, um ihre Abos zu verwalten. Nutzer können registriert oder (je nach Implementierung) auch als Gast agieren.
 | Anwender, Benutzer; abzugrenzen von „Administrator"
 
-| Produkt
-| Ein im System angebotener Artikel, der bestellt werden kann. Ein Produkt hat eine
-  Bezeichnung, einen Preis und eine Verfügbarkeit.
-| Artikel, Ware
+| Erfassung
+| Das Hinzufügen eines Abos in SubscriptionGuard — entweder manuell durch den Nutzer oder automatisch durch Erkennung (aus E-Mails, Kontoauszügen).
+| Anlegen, Registrieren; abzugrenzen von Bearbeiten/Ändern
 
-| [Begriff]
-| [Präzise, fachliche Definition in 1–3 Sätzen]
-| [Synonyme oder Abgrenzungen zu ähnlichen Begriffen]
+| Manuelle Erfassung
+| Der Nutzer gibt die Abo-Details selbst ein (Name, Betrag, Intervall, Datum, etc.).
+| Abzugrenzen von automatischer Erfassung
 
-| [Begriff]
-| [Präzise, fachliche Definition in 1–3 Sätzen]
-| [Synonyme oder Abgrenzungen zu ähnlichen Begriffen]
+| Automatische Erfassung
+| Das System erkennt Abos selbstständig aus verknüpften Quellen (z. B. E-Mail-Postfach, Bankdaten) und schlägt sie dem Nutzer zur Bestätigung vor.
+| Auto-Detection, automatische Erkennung; setzt Nutzererlaubnis voraus
+
+| Import
+| Das Einlesen von Abo-Daten aus einem externen Format (z. B. CSV, Excel) in SubscriptionGuard.
+| Datenimport; abzugrenzen von automatischer Erfassung
+
+| Export
+| Das Ausgeben von Abo-Daten aus SubscriptionGuard in ein externes Format.
+| Datenexport; relevant für Datenhoheit und Datenschutz
+
+| Preisänderung
+| Eine Änderung des Zahlungsbetrags eines Abos durch den Anbieter, die dem Nutzer als Warnung angezeigt werden soll.
+| Preisanpassung, Preiserhöhung
+
+| Einsparpotenzial
+| Eine von der App identifizierte Möglichkeit, Abokosten zu reduzieren — z. B. durch Kündigung ungenutzter Abos, Wechsel zu günstigeren Alternativen oder Zusammenlegung ähnlicher Abos.
+| Sparpotenzial, Optimierungspotenzial
+
+| Handlungsempfehlung
+| Ein konkreter Vorschlag der App an den Nutzer, wie er seine Abo-Situation verbessern kann (z. B. „Dieses Abo nutzt du seit 3 Monaten nicht — kündigen?").
+| Empfehlung, Suggestion
+
+| Datenschutz / Datenhoheit
+| Das Recht und die Möglichkeit des Nutzers, zu kontrollieren, welche seiner Daten wie gespeichert und verwendet werden. Umfasst Einstellungen zur Datenweitergabe, lokale Speicherung und Export.
+| Privacy, DSGVO-Konformität
 |===
 
+---
 
 == Domänenmodell
 
-_Das Domänenmodell zeigt die wichtigsten fachlichen Konzepte (Entitäten) und ihre Beziehungen.
-Es beschreibt die Realität des Problemraums, nicht die Datenbankstruktur._
+_Das Domänenmodell zeigt die wichtigsten fachlichen Konzepte und ihre Beziehungen. Es beschreibt die Realität des Problemraums, nicht die Datenbankstruktur._
 
 === Diagramm
-
-//Fügen Sie hier ein Diagramm ein — entweder als eingebettetes PlantUML oder als exportiertes Bild.
 
 [plantuml, domain-model, svg]
 ....
 @startuml
-' Beispiel — bitte durch das echte Domänenmodell ersetzen
+skinparam monochrome true
+skinparam defaultFontSize 12
 
 entity Nutzer {
   Name
   E-Mail
 }
 
-entity Bestellung {
-  Bestellnummer
-  Datum
-  Status
+entity Abo {
+  Produktname
+  Zahlungsbetrag
+  Zahlungsintervall
+  Abschlussdatum
+  Kündigungsfrist
+  AutomatischeVerlängerung
 }
 
-entity Produkt {
+entity Vertragspartner {
+  Name
+  Kündigungsweg
+}
+
+entity Kategorie {
   Bezeichnung
-  Preis
 }
 
-Nutzer "1" --> "0..*" Bestellung : gibt auf
-Bestellung "1" --> "1..*" Produkt : enthält
+entity Erinnerung {
+  Datum
+  Typ
+}
+
+entity Kennzahl {
+  GesamtkostenProMonat
+  AnzahlAktiveAbos
+}
+
+Nutzer "1" --> "0..*" Abo : verwaltet
+Abo "0..*" --> "1" Vertragspartner : hat
+Abo "0..*" --> "0..1" Kategorie : gehört zu
+Abo "1" --> "0..*" Erinnerung : löst aus
+Nutzer "1" --> "1" Kennzahl : sieht
 
 @enduml
 ....
 
-NOTE: Das Domänenmodell wird im Laufe des Projekts weiterentwickelt.
-Änderungen sollten immer gemeinsam im Team besprochen und hier nachgepflegt werden.
-
 === Beschreibung der Entitäten
-
-Kurze Erläuterung zu den im Modell enthaltenen Entitäten.
 
 [cols="1,3", options="header"]
 |===
 | Entität | Beschreibung
 
 | Nutzer
-| [Beschreibung der Entität und ihrer Rolle im System]
+| Die Person, die SubscriptionGuard verwendet. Verwaltet eine Liste von Abos und sieht aggregierte Kennzahlen.
 
-| Bestellung
-| [Beschreibung der Entität und ihrer Rolle im System]
+| Abo
+| Die zentrale Entität: ein wiederkehrendes Abonnement mit allen relevanten Details (Betrag, Intervall, Frist etc.).
 
-| Produkt
-| [Beschreibung der Entität und ihrer Rolle im System]
+| Vertragspartner
+| Das Unternehmen oder der Dienst, bei dem das Abo besteht (z. B. Netflix, Spotify). Hat einen definierten Kündigungsweg.
 
-| [Weitere Entität]
-| [Beschreibung]
+| Kategorie
+| Eine Klassifikation für Abos, die Filterung und Gruppierung ermöglicht (z. B. Streaming, Sport, Software).
+
+| Erinnerung
+| Eine termingebundene Benachrichtigung, die auf eine nahende Kündigungsfrist oder Verlängerung hinweist.
+
+| Kennzahl
+| Aggregierte Auswertung aller Abos eines Nutzers — z. B. Gesamtkosten pro Monat, Anzahl aktiver Abos.
 |===
 
 === Beschreibung der Beziehungen
-
-Beschreibung der wichtigsten Beziehungen zwischen den Entitäten, sofern diese besondere Kardinalitäten haben oder aus anderen Gründen erklärungsbedürftig sind.
 
 [cols="1,1,1,3", options="header"]
 |===
 | Von | Zu | Kardinalität | Bedeutung
 
 | Nutzer
-| Bestellung
+| Abo
 | 1 zu 0..*
-| Ein Nutzer kann keine oder mehrere Bestellungen aufgeben.
+| Ein Nutzer kann kein oder mehrere Abos verwalten.
 
-| Bestellung
-| Produkt
-| 1 zu 1..*
-| Eine Bestellung enthält mindestens ein Produkt.
+| Abo
+| Vertragspartner
+| 0..* zu 1
+| Jedes Abo gehört zu genau einem Vertragspartner.
 
-| [Entität]
-| [Entität]
-| [z. B. 0..* zu 1]
-| [Beschreibung der Beziehung in natürlicher Sprache]
+| Abo
+| Kategorie
+| 0..* zu 0..1
+| Ein Abo kann einer Kategorie zugeordnet sein (optional).
+
+| Abo
+| Erinnerung
+| 1 zu 0..*
+| Aus einem Abo können mehrere Erinnerungen (Kündigungsfrist, Verlängerung) entstehen.
+
+| Nutzer
+| Kennzahl
+| 1 zu 1
+| Ein Nutzer sieht eine aggregierte Kennzahl-Übersicht über alle seine Abos.
 |===
 
-_Dieses Dokument wird kontinuierlich gepflegt. Änderungen an Fachbegriffen oder Beziehungen
-müssen hier nachgezogen werden, bevor sie in User Stories oder Code einfließen._
+---
+
+_Dieses Dokument wird kontinuierlich gepflegt. Änderungen an Fachbegriffen oder Beziehungen müssen hier nachgezogen werden, bevor sie in User Stories oder Code einfließen._

--- a/docs/product/product_concept.adoc
+++ b/docs/product/product_concept.adoc
@@ -1,55 +1,45 @@
 = Produktkonzept: {project-name}
-Vorname Nachname <email@domain.org>; Vorname2 Nachname2 <email2@domain.org>; Vorname3 Nachname3 <email3@domain.org>
+Jannik Thiele; Niels Wiesner; Quôc Dat Nguyên; Juan Ramiro Groh Fili; Johannes Meinck; Franz Rehschuh; Lennox Schmollny
 {localdatetime}
 include::../_includes/default-attributes.inc.adoc[]
-// Platzhalter für weitere Dokumenten-Attribute
 
+_Dieses Dokument beschreibt das Produkt auf konzeptioneller Ebene — was gebaut wird, warum, für wen, und unter welchen Rahmenbedingungen. Es richtet sich an alle Projektbeteiligten: Stakeholder, Product Owner, Designer und Entwickler:innen._
 
-_Dieses Dokument beschreibt das Produkt auf konzeptioneller Ebene — was gebaut wird, warum, für wen, und unter welchen Rahmenbedingungen. Es richtet sich an alle Projektbeteiligten:
-Stakeholder, Product Owner, Designer und Entwickler:innen._
-
-_Das Dokument ist so aufgebaut, dass es relativ stabil bleibt. Detaillierte UX-Artefakte wie Personas, Nutzerkontext,
-Interaktionsflüsse und Design-Entscheidungen sind im UX-Konzept beschrieben._
+_Das Dokument ist so aufgebaut, dass es relativ stabil bleibt. Detaillierte UX-Artefakte wie Personas, Nutzerkontext, Interaktionsflüsse und Design-Entscheidungen sind im UX-Konzept beschrieben._
 
 ---
 
 == Motivation
 
-_Warum wird dieses Produkt gebaut? Welches Problem existiert heute, und warum ist es relevant?
-Dieser Abschnitt beschreibt den Ausgangszustand und den Handlungsbedarf — ohne bereits eine
-Lösung zu nennen. 3–5 Sätze genügen._
+Nahezu jeder Mensch sieht sich heutzutage zunehmend mit Abomodellen konfrontiert.
+Abomodelle sind von Natur aus unübersichtlich und unberechenbar: wiederkehrende Kosten mit unterschiedlichem Beginn, Iteration, Kündigungsfristen und Überraschungen.
+Abonnements erschweren, besonders in der Menge, ein bewusstes, transparentes und verantwortungsvolles Finanzmanagement.
+Es fehlt eine einheitliche Übersicht, die einem schnell einen Überblick gibt — sodass ein Handlungsbedarf in der eigenen Kostenorganisation schnell getroffen werden kann.
 
-[Hier die Ausgangssituation und den Handlungsbedarf beschreiben. Beispiel:
-„Studierende an der Hochschule haben heute keinen zentralen Überblick über verfügbare
-Lernräume. Die Suche nach freien Plätzen kostet täglich wertvolle Zeit und führt zu Frust.
-Eine einfache, mobil nutzbare Lösung fehlt bisher."]
-
-Nahezu jeder Mensch sieht sich heutzutage zunehmend mit Abomodellen konfrontiert. Doch Abonnements erschweren, besonders in der Menge, ein bewusstes, transparentes und verantwortungsvolles Finanzmanagement, da sie von Natur aus unübersichtlich und unberechnbar sind. Es fehlt der Überblick und spezialisierte, einfach gehaltene Tools.
+Moderne Unternehmen fokussieren sich mehr und mehr auf Abo-Modelle statt Einmalkäufe.
+Sie spekulieren und setzen bewusst auf Unübersichtlichkeit der monatlichen Zahlungen durch Rabattcodes, kostenlose Monate, Jahrestarife und Feature-Vergleichstabellen.
+All das macht das Preis-Leistungs-Verhältnis schwer zu erfassen, und Ausgaben in der Summe schwer vorherzusehen.
 
 == Produktvision
 
-_Die Produktvision beschreibt in einem oder wenigen Sätzen den angestrebten Zielzustand.
-Sie ist inspirierend, prägnant und stabil — sie sollte sich über die gesamte Projektlaufzeit
-nicht wesentlich verändern._
+_Die Produktvision beschreibt in einem oder wenigen Sätzen den angestrebten Zielzustand._
 
 === Visions-Statement
 
 ____
-Für Studenten die zunehmend mit Abomodellen konfrontiert sind, ist SubscriptionGuard eine App, die ihnen hilft ihre Abonnements schnell zu überblicken und komfortabel zu verwalten. Im Gegensatz zur Konkurrenz bietet unser Produkt eine überschaubare und leicht zu bedienende UX.
+Für Studenten, die zunehmend mit Abomodellen konfrontiert sind, ist SubscriptionGuard eine App, die ihnen hilft, ihre Abonnements schnell zu überblicken und komfortabel zu verwalten.
+Im Gegensatz zu Finanzguru bietet unser Produkt eine überschaubare und leicht zu bedienende UX.
 ____
-
-//Beispiel: Für Studierende der HTWD, die zu wenig Zeit in der Mittagspause zum Essen haben, ist Flying Burger ein  Lieferdient für Burger, der per Drohne liefert. Anders als landgestützte Lieferdienste kann unser Produkt durchs Fenster direkt in den Hörsaal liefern.
-
-NOTE: Das Visions-Statement kann im Team mit der „Elevator Pitch"-Methode oder dem „Future Press Release"-Format erarbeitet werden.
 
 === Zielbild
 
-_Optional: Beschreibe in 2–4 Sätzen, wie die Welt mit diesem Produkt aussieht. Was hat sich für die Nutzer:innen verändert?_
-//[Hier das Zielbild beschreiben]
+Für alle Personen, die Abomodelle nutzen, ist SubscriptionGuard eine App/Webapp, um Abomodelle hinzuzufügen oder automatisch einzubinden und in wenigen Übersichten in einem Blick die wichtigsten Informationen zum Verwalten zu erhalten.
 
+Wir bauen eine Abomodel-Übersicht und Vergleichsplattform für Abo-Kunden aller Art.
+Wir managen bestehend wiederkehrende Ausgaben in Abomodellen des Kunden.
+Wir zeigen ihm, was er monatlich zahlt und wofür er es erhält, dabei bewahren wir ihn vor Marketing-Maschen, irreführenden Zahlungskonditionen und Produktfeatures.
 
 == Produktpositionierung
-_Wer sind die Zielgruppen, und wie positioniert sich das Produkt im Vergleich zu bestehenden Alternativen?_
 
 === Zielgruppen
 
@@ -58,17 +48,16 @@ _Wer sind die Zielgruppen, und wie positioniert sich das Produkt im Vergleich zu
 | Zielgruppe | Beschreibung
 
 | Studierende
-| Technisch erfahren mit einer Vielzahl digitaler Abonnements in einer vergleichsweise schwierigen? finanziellen Situation.
+| Technisch erfahren, mit einer Vielzahl digitaler Abonnements (Streaming, Lizenzen, Gym) in einer vergleichsweise schwierigen finanziellen Situation. Verlieren schnell den Überblick über laufende Kosten und Kündigungsfristen.
 
-| junge Leute allgemein
-| 20 - 50 Jahre mit vielen Abonnements
+| Junge Leute allgemein (20–50 Jahre)
+| Viele digitale Abos, fehlendes Verständnis über Gesamtausgaben, verlieren schnell den Überblick. Einschließlich WG-Mitglieder, Freelancer, Familien und technikoffene Personen.
 
-| [Weitere Zielgruppe]
-| [Kurzbeschreibung]
+| Technisch weniger erfahrene Nutzer
+| Ältere oder technikfernere Personen, die Hilfe beim Verwalten digitaler Abos benötigen und eine einfache, geführte Oberfläche brauchen.
 |===
 
-NOTE: Ausführliche Beschreibungen der Nutzenden — Personas, Nutzungskontext,
-typische Aufgaben — sind im link:ux_concept.adoc[UX-Konzept] dokumentiert.
+NOTE: Ausführliche Beschreibungen der Nutzenden — Personas, Nutzungskontext, typische Aufgaben — sind im link:ux_concept.adoc[UX-Konzept] dokumentiert.
 
 === Wettbewerb & Alternativen
 
@@ -76,161 +65,170 @@ typische Aufgaben — sind im link:ux_concept.adoc[UX-Konzept] dokumentiert.
 |===
 | Alternative | Beschreibung | Warum unser Produkt besser passt
 
-| [z. B. E-Mail-Anfrage an Sekretariat]
-| [Wie lösen Nutzer:innen das Problem heute?]
-| [Worin liegt unser Vorteil?]
+| Finanzguru
+| Umfassende Finanz-App mit Abo-Übersicht als Teilfunktion. Verbindet sich mit Bankkonten, analysiert Ausgaben breit.
+| SubscriptionGuard fokussiert sich ausschließlich auf Abos — einfacher, übersichtlicher, kein Bankzugang nötig.
 
-| [z. B. Aushang an schwarzem Brett]
-| [Beschreibung]
-| [Unterschied]
+| Papier / Excel / Notizen
+| Manuelle Führung von Abo-Listen durch den Nutzer selbst.
+| Keine automatische Erkennung, keine Erinnerungen, kein strukturierter Überblick.
 
-| [Weitere Alternative]
-| [Beschreibung]
-| [Unterschied]
+| Kontoauszüge / E-Mails
+| Nutzer versuchen, Abos selbst durch Durchsuchen von Kontoauszügen oder E-Mails nachzuvollziehen.
+| Zeitaufwändig, fehleranfällig, keine proaktiven Hinweise auf Kündigungsfristen.
 |===
 
-
 == Stakeholder
-
-Wer hat Einfluss auf das Produkt oder ein Interesse an dessen Erfolg? Stakeholder formen oft Anforderungen und Rahmenbedingungen — ihre Nennung hier
-erklärt, warum bestimmte Entscheidungen getroffen wurden.
 
 [cols="1,2,2,1", options="header"]
 |===
 | Stakeholder | Rolle / Interesse | Erwartungen an das Produkt | Einfluss
 
-| Studenten
+| Studenten (Nutzer)
 | Hauptnutzer; wollen Abo-Konditionen überblicken und optimieren
-a| 
-* Übersichtlichkeit, einfache Bediernung, möglichst wenig manuelle Arbeit
-* Einfaches Abo-Management
-* Hilfe Abo-Nutzen zu bewerten
-* geräteunabhängige Benutzung
-* vertrauliche Behandlung von Finanzdaten
+a|
+* Übersichtlichkeit, einfache Bedienung
+* Einfachheit bei Management von Abos (automatische Erfassung?)
+* Hilfe bei Vermeidung von Abos (Alternativen, Zusammenfassen, …)
+* Geräteunabhängig
+* Möglichst wenig manuelle Arbeit
+* Vertraulichkeit
 | Hoch
+
+| Anbieter von Abomodellen (Produktgegner)
+| Großteils negatives Interesse, da SubscriptionGuard gegen Geschäftsinteressen arbeitet. Eventuell aber teils offen für Integration (automatische Erfassung).
+| Kündigungsschreiben muss Mindestanforderungen entsprechen.
+| niedrig – mittel
+
+| Anbieter von Abomodellen (Werbekunde/Partner)
+| Positives Interesse an Werbung auf der Plattform, Bewerben günstiger Abos, Nutzer ergänzende Abos vorschlagen.
+| Kündigungsschreiben muss Mindestanforderungen entsprechen.
+| Mittel
+
+| Produktgegner
+| Anbieter Abomodelle, Geschäftsinteressen bedroht von SubscriptionGuard. Menschen, die nicht möchten, dass ihre Überweisungen überwacht werden.
+| Negatives Interesse; keine Bankverbindung gewollt.
+| niedrig
+
+| Werbekunden / Partner
+| Anbieter Abomodelle, SubscriptionGuard fördert Geschäftsinteressen.
+| Interesse an Werbung auf der Plattform, Bewerben von günstigeren Abos, Nutzer ergänzende Abos vorschlagen.
+| niedrig
 
 | Entwicklerteam
 | Betreiben, Warten, Anpassen der Plattform
 a|
-* Umsetzung im Rahmen der Fähigkeiten
+* Im Rahmen unserer Fähigkeiten
 * Komplexität gering halten
-* möglichst viele Bibliotheken verwenden
-* rechtlichen Aufwand gering halten
+* Möglichst viele Bibliotheken verwenden
+* Rechtlichen Aufwand gering halten
 | Hoch
 
-| Anbieter von Abomodellen
-| Bieten Gestaltungsgrundlage für Erfassung, Kündigung der Abos
-| Einhalten bestimmter Formate zur integrierten Erfassung / Kündigung
+| Behörden
+| Einhaltung der Gesetzgebung
+| Einhaltung von Nutzerinteressen/Datenschutz; kein unerlaubtes Weiterleiten von Daten an Dritte; ordnungsgemäße Datenspeicherung (verschlüsselt, …)
+| Hoch
+
+| Zahlungsdienstleister
+| API-Anbindung
+a|
+* Abos automatisch aus Abbuchungen auslesen
+* An API angewiesen
+| (sehr) gering
+
+| Plattformbetreiber von App-Stores
+| Vertriebskanal
+| Erfüllt die Anforderungen der jeweiligen Plattform.
+| gering
+
+| Datenanbieter (z. B. Vergleichsportale)
+| Liefern Preise, Alternativen und Marktinfos
+| —
 | Mittel
-
-| Werbekunden / Partner   
-| Anbieter Abomodelle, Produkt fördert Geschäftsinteressen
-| Interesse an Werbung auf der Platform, Bewerben von ihren günstigeren Abos, Nutzer ergänzende Abos vorschlagen
-| niedrig
-
-[.not-really]
-| Produktgegner
-| Anbieter Abomodelle, Produkt bedrohen Geschäftsinteressen
-| Das Produkt offenbart ggf. Geschäftsmodelle die auf der Unübersichtlichkeit von Abomodellen beruhen
-| niedrig
 |===
 
 == Hauptfunktionen
-
-Welche Kernfunktionen muss das Produkt bieten, um die Produktvision zu erfüllen? Jede Funktion ist direkt auf einen Nutzerbedarf zurückgeführt — nicht als technische Anforderung, sondern als Antwort auf ein Nutzungsproblem.
-
-Diese Hauptfunktionen sollten als Epics im Product Backlog für die Gruppierung von User Stories verwendet werden.
 
 [cols="2,2,1", options="header"]
 |===
 | Nutzerbedarf | Hauptfunktion | Priorität
 
-| Studierende wollen schnell sehen, welche Räume gerade frei sind.
-| Echtzeit-Übersicht freier Lernräume
+| Nutzer wollen schnell sehen, welche Abos sie haben und was sie insgesamt kosten.
+| Einfacher, schneller Überblick über Abos (Liste, Kennzahlen, Detailansicht)
 | Hoch
 
-| Nutzer:innen wollen einen Raum für einen bestimmten Zeitraum reservieren.
-| Raumbuchung mit Zeitfenster
+| Nutzer wollen Abos erfassen, ändern und verwalten — mit möglichst wenig Aufwand.
+| Verwaltung der Abos schnell und direkt in der App (manuelle Erfassung, Änderung, Löschung, Import)
 | Hoch
 
-| Nutzer:innen wollen ihre aktiven Buchungen verwalten.
-| Buchungsübersicht & Stornierung
+| Nutzer wollen unnötige Abos erkennen und reduzieren.
+| Aboanzahl reduzieren (unnötige Abos anzeigen, Warnungen, Schranken setzen)
 | Mittel
 
-| Verwaltung will die Auslastung der Räume analysieren.
-| Auslastungsberichte für Administratoren
-| Niedrig
+| Nutzer wollen Einsparpotenziale entdecken und Abos vergleichen.
+| Personalisierte Einsparpotenziale entdecken (erweiterte Kennzahlen, Abo-Vergleich, Handlungsempfehlungen)
+| Mittel
 
-| [Nutzerbedarf]
-| [Hauptfunktion]
-| [Hoch / Mittel / Niedrig]
+| Nutzer wollen Kündigungsfristen nicht verpassen.
+| Erinnerung an Kündigungsfristen (Benachrichtigungen, Anzeige nahender Fristen)
+| Hoch
+
+| Nutzer wollen Datenhoheit und Transparenz über ihre gespeicherten Daten.
+| Datenhoheit / Datenschutz (Export, lokale Speicherung, Privacydashboard, feinere Berechtigungen)
+| niedrig
 |===
-
-NOTE: Die Reihenfolge entspricht einer ersten groben Priorisierung und wird im Rahmen
-der Backlog-Priorisierung verfeinert.
 
 == Qualitätsziele & Einschränkungen
 
-_Dieser Abschnitt beschreibt, unter welchen Rahmenbedingungen das Produkt entwickelt
-und betrieben wird. Es wird unterschieden zwischen Qualitätszielen (angestrebte
-Eigenschaften) und Einschränkungen (nicht verhandelbare Rahmenbedingungen)._
-
 === Qualitätsziele
-
-_Qualitätsziele sind messbare oder zumindest überprüfbare Eigenschaften, die das
-Produkt erfüllen soll. Sie sollten spezifisch genug sein, um als Testkriterium zu dienen._
-
-NOTE: Dieses Dokument ist die einzige Quelle für Qualitätsziele und Einschränkungen.
-Das link:../technical/architecture.adoc[Architektur]-Dokument referenziert diese Anforderungen und dokumentiert die
-technischen Entscheidungen, die sich daraus ergeben — ohne sie hier zu wiederholen.
 
 [cols="1,3,2", options="header"]
 |===
 | Qualitätsziel | Beschreibung | Messkriterium
 
 | Benutzbarkeit
-| Das Produkt ist ohne Einarbeitung nutzbar.
-| Neue Nutzer:innen finden die Kernfunktion innerhalb von 2 Minuten ohne Hilfe.
+| Das Produkt ist ohne Einarbeitung nutzbar; einfache, übersichtliche Oberfläche.
+| Neue Nutzer:innen finden die Kernfunktion (Abo erfassen) innerhalb von 2 Minuten ohne Hilfe.
 
 | Performance
 | Das Produkt reagiert schnell auf Nutzerinteraktionen.
 | Seitenladezeit unter 2 Sekunden bei normaler Netzwerkverbindung.
 
-| Verfügbarkeit
-| Das Produkt ist während der Hochschulöffnungszeiten zuverlässig erreichbar.
-| Verfügbarkeit ≥ 99 % während Betriebszeiten.
+| Datenschutz & Vertraulichkeit
+| Finanzdaten der Nutzer werden vertraulich behandelt und nicht unbefugt weitergegeben.
+| Daten werden verschlüsselt gespeichert; kein Weitergeben an Dritte ohne explizite Zustimmung; DSGVO-konform.
 
-| [Qualitätsziel]
-| [Beschreibung]
-| [Messkriterium]
+| Geräteunabhängigkeit
+| Das Produkt ist auf verschiedenen Endgeräten nutzbar.
+| Funktioniert auf Smartphone (iOS, Android) und Desktop-Browser ohne Einschränkungen.
+
+| Verfügbarkeit
+| Das Produkt ist zuverlässig erreichbar.
+| Verfügbarkeit ≥ 99 % während Betriebszeiten.
 |===
 
 === Einschränkungen
-
-_Einschränkungen sind Rahmenbedingungen, die nicht verhandelbar sind — technische,
-organisatorische, rechtliche oder zeitliche Vorgaben._
 
 [cols="1,2,1", options="header"]
 |===
 | Einschränkung | Beschreibung | Kategorie
 
-| Betrieb auf Hochschulinfrastruktur
-| Das System muss auf den vorhandenen Servern der Hochschule betrieben werden können.
-| Technisch
-
 | DSGVO-Konformität
-| Personenbezogene Daten dürfen nur gemäß DSGVO verarbeitet und gespeichert werden.
+| Personenbezogene Daten — insbesondere Finanzdaten — dürfen nur gemäß DSGVO verarbeitet und gespeichert werden. Kein unerlaubtes Weiterleiten an Dritte.
 | Rechtlich
 
 | Projektlaufzeit
 | Das Produkt muss innerhalb eines Semesters (ca. 4 Monate) lieferbar sein.
 | Zeitlich
 
-| [Einschränkung]
-| [Beschreibung]
-| [Technisch / Rechtlich / Organisatorisch / Zeitlich]
-|===
+| Komplexität gering halten
+| Die Implementierung soll im Rahmen der Teamfähigkeiten bleiben; möglichst vorhandene Bibliotheken nutzen.
+| Organisatorisch
 
+| Keine Bankverbindung als Pflicht
+| Die automatische Erfassung über Bankkonten ist optional — das Produkt muss auch ohne Bankanbindung vollständig nutzbar sein.
+| Technisch
+|===
 
 == Versionsverlauf
 
@@ -239,12 +237,14 @@ organisatorische, rechtliche oder zeitliche Vorgaben._
 | Version | Datum | Änderung
 
 | 1.0
-| [Datum]
-| Initiale Version nach Kick-off-Workshop
+| Mai 2025
+| Initiale Version nach Kick-off und Stakeholder-Analyse im Miro Board
 
+| 1.1
+| Mai 2025
+| Hauptfunktionen und Qualitätsziele ergänzt auf Basis der User Story Map
 |===
 
 ---
 
-_Dieses Dokument ist bewusst stabil gehalten. Änderungen sollten nur bei wesentlichen
-Richtungsentscheidungen vorgenommen werden und im Versionsverlauf dokumentiert sein._
+_Dieses Dokument ist bewusst stabil gehalten. Änderungen sollten nur bei wesentlichen Richtungsentscheidungen vorgenommen werden und im Versionsverlauf dokumentiert sein._

--- a/docs/product/ux_concept.adoc
+++ b/docs/product/ux_concept.adoc
@@ -1,143 +1,296 @@
 = UX-Konzept: {project-name}
-Vorname Nachname <email@domain.org>; Vorname2 Nachname2 <email2@domain.org>; Vorname3 Nachname3 <email3@domain.org>
+Jannik Thiele; Niels Wiesner; Quôc Dat Nguyên; Juan Ramiro Groh Fili; Johannes Meinck; Franz Rehschuh; Lennox Schmollny
 {localdatetime}
 include::../_includes/default-attributes.inc.adoc[]
-// Platzhalter für weitere Dokumenten-Attribute
 
-_Dieses Dokument beschreibt, wer das Produkt nutzt und wie — aus der Perspektive der Nutzenden. Es ergänzt das Produktkonzept um Personas, Nutzungskontext und
-systemweite Interaktionsflüsse und dient als gemeinsame Referenz für Design- und Entwicklungsentscheidungen._
+_Dieses Dokument beschreibt, wer das Produkt nutzt und wie — aus der Perspektive der Nutzenden. Es ergänzt das Produktkonzept um Personas, Nutzungskontext und systemweite Interaktionsflüsse und dient als gemeinsame Referenz für Design- und Entwicklungsentscheidungen._
 
-_Individuelle Wireframes einzelner Features werden direkt in den zugehörigen User Stories im Product Backlog gepflegt (verlinkt oder kopiert aus Miro oder anderem Tool). Dieses Dokument enthält nur Artefakte, die mehrere Stories oder das gesamte Produkt betreffen._
+_Individuelle Wireframes einzelner Features werden direkt in den zugehörigen User Stories im Product Backlog gepflegt. Dieses Dokument enthält nur Artefakte, die mehrere Stories oder das gesamte Produkt betreffen._
 
 ---
 
 == Personas
 
-_Personas sind fiktive, aber realitätsbasierte Beschreibungen typischer Nutzender.
-Sie helfen dem Team, Entscheidungen konsequent aus Nutzerperspektive zu treffen.
-Personas sollten auf echten Nutzerinterviews oder Beobachtungen basieren — nicht
-auf Annahmen allein._
+_Personas sind fiktive, aber realitätsbasierte Beschreibungen typischer Nutzender. Sie helfen dem Team, Entscheidungen konsequent aus Nutzerperspektive zu treffen._
 
-_Hinweis: Im link:product_concept.adoc[Produktkonzept] werden Zielgruppen nur benannt. Hier werden sie als Personas ausgearbeitet._
-
-=== Persona 1: [Name]
+=== Persona 1: Otto Normal ⭐ (Priorität 9 — Kernpersona)
 
 [cols="1,3"]
 |===
 | *Rolle*
-| [z. B. Studierende im 3. Semester, Informatik]
+| Studierender, ab ca. 20 Jahren; technisches Niveau 5/10
 
-| *Alter*
-| [z. B. 22 Jahre]
+| *Fokus*
+| Einfachheit, Überblick, Verwaltung
 
 | *Zitat*
-| _„[Ein prägnanter Satz, der ihre Haltung oder ihr Problem auf den Punkt bringt.]"_
+| _„Ich will einfach meine Abos in den Griff bekommen."_
 
 | *Ziele*
-| [Was will diese Person erreichen? Was motiviert sie?]
+a|
+* Einfacher, schneller Überblick über alle Abos
+* Abgeschlossene Abos am liebsten automatisch erfassen
+* Abo-Konditionen einsehen, nahende Verlängerungen erkennen
+* Verwaltung der Abos schnell und direkt in der App
+* Abos so einfach wie möglich kündigen
+* Über nahende Kündigungsfristen informiert werden
+* Einfache Handlungsempfehlungen und Kennzahlen
 
 | *Frustrationen*
-| [Was hindert sie heute daran, ihre Ziele zu erreichen?]
+a|
+* Vergisst Abos, Kündigungsfristen und sich ändernde Kosten
+* Nimmt sich vor, Abos zu kündigen — verliert es jedoch aus den Augen
+* Schätzt Gesamtkosten der Abos in der Zukunft schwierig ein
+* Hat keine Lust auf jede Plattform einzeln zu gehen
+* Deckt viele Studenten ab — nutzt gern Test-Abos
 
 | *Verhalten & Kontext*
-| [Wie und wann nutzt sie digitale Produkte? Welche Geräte? Welche Erfahrung?]
+a|
+* Faul: kein Bock, manuell Abos einzugeben
+* Nicht stolz darauf, digitale Produkte zu nutzen, die er nicht zwingend benötigt
+* Nutzt die App nicht täglich — eher beim monatlichen Überblick oder bei Bedarf
+* Eher Smartphone-Nutzung, unterwegs oder zu Hause auf dem Sofa
 
 | *Bezug zum Produkt*
-| [Warum ist dieses Produkt für sie relevant? Was ist ihr primärer Nutzen?]
+a|
+* Einfache, simple Übersicht
+* Kostenverlauf der Abomodelle
+* Kündigung direkt über die App
+* Automatische Abo-Erfassung (nice to have)
 |===
 
-=== Persona 2: [Name]
+---
+
+=== Persona 2: Thomas der Skeptische (Priorität 7)
 
 [cols="1,3"]
 |===
 | *Rolle*
-| [z. B. Verwaltungsangestellte, zuständig für Raumvergabe]
+| Ca. 20 Jahre, tendiert zu älteren Altersklassen; technisches Niveau 7/10
 
-| *Alter*
-| [z. B. 45 Jahre]
+| *Fokus*
+| Datenschutz & Transparenz
 
-| *Zitat*
-| _„[Prägnantes Zitat]"_
+| *Zitate*
+a|
+* _„Die da oben"_
+* _„Lieber zur nächsten Bankfiliale als Online-Bank"_
+* _„Nur Bares ist Wahres"_
 
 | *Ziele*
-| [Ziele]
+a|
+* Will keinesfalls abhängig sein von technischen Unternehmen
+* Will nicht Geld in digitale Dienste investieren und sich nicht verarmen lassen
+* Schätzt vertrauenswürdige, transparente Dienstleister SEHR
 
 | *Frustrationen*
-| [Frustrationen]
+a|
+* Hat das Gefühl, er wird von digitalen Produkten ausgebeutet
+* Bekommt Bauchschmerzen, wenn er daran denkt, seine persönlichen / finanziellen Daten digital gespeichert zu sehen
+* Ist äußerst skeptisch gegenüber jeder Art von Online-Finanzdienstleistung
 
 | *Verhalten & Kontext*
-| [Verhalten & Kontext]
+a|
+* Befasst sich mit Finanzen nur samstags abends am PC / Laptop
+* Nutzt immer die gleichen digitalen Produkte
+* Schätzt sehr darauf, welche Daten er von sich gibt
 
 | *Bezug zum Produkt*
-| [Bezug zum Produkt]
+a|
+* SubscriptionGuard hilft Einsparpotenziale zu entdecken
+* Hilft überflüssige Abonnements zu entlarven
+* Gibt Thomas klare Kontrolle über seine eigenen finanziellen Abhängigkeiten
+* Freigabe/Berechtigung von Daten detailliert einstellbar
+* Transparente Datenpolitik (Privacydashboard?)
 |===
 
-NOTE: Für jedes Projekt sind 2–4 Personas ausreichend. Mehr Personas verwässern
-den Fokus. Wenn eine Persona in keiner User Story vorkommt, wird sie gestrichen.
+---
+
+=== Persona 3: Maximilian der Fortschrittliche (Priorität 7)
+
+[cols="1,3"]
+|===
+| *Rolle*
+| Tendenziell jüngere Zielgruppe, noch offen für neue Anwendungen und Tools; technisches Niveau 9/10
+
+| *Fokus*
+| Bestmögliche Optimierung
+
+| *Ziele*
+a|
+* Egal wie, Abokosten verringern
+* Einsparpotenziale entdecken
+* Nutzung von Abomodellen analysieren, Unterstützung bei Abo-Vergleich / Konkurrenz
+* Visualisierung / Statistiken, Ausgaben, Einsparung
+
+| *Frustrationen*
+a|
+* Fehlende aussagekräftige Informationen/Statistiken über Nutzung/Wert von Abodiensten
+* Bisher manuelle Erfassung von Abodiensten
+* Fehlende Handlungsempfehlungen
+
+| *Verhalten & Kontext*
+a|
+* Für 95 % digitaler Dienste nutzt er sein Handy — immer die neuesten Tools, insbesondere KI (Early Adopter)
+* Besitzt gern viele Abos und Tools
+* Engagiert und straightforward
+* Gutes finanzielles Verständnis
+
+| *Bezug zum Produkt*
+a|
+* Detaillierte Analysen
+* Automatische Abo-Erfassung
+* Zugeschnittene Handlungsempfehlungen
+|===
+
+---
+
+=== Persona 4: Enrico WG (Priorität 5)
+
+[cols="1,3"]
+|===
+| *Rolle*
+| Jüngere Zielgruppe bis ca. 30 Jahre, WG-Bewohner; technisches Niveau 5/10
+
+| *Fokus*
+| Splitting & Kostenteilung/Kontrolle
+
+| *Ziele*
+a|
+* Abokosten mit anderen WG-Mitgliedern teilen/überblicken
+* Übersicht über alle von WG-Mitgliedern bezahlten Abos behalten
+* Abokosten durch Zusammenlegen auf ein Gruppenabo reduzieren
+
+| *Frustrationen*
+a|
+* Verliert Übersicht über beteiligte Personen und geteilte Ausgaben
+* Hohe Kosten: zu viele doppelte Abos pro Kategorie
+* Schwierig, Abokosten effektiv mit Dritten zu verringern
+
+| *Bezug zum Produkt*
+a|
+* Teilen von Abos bzw. Accounts
+* Zusammenführen mehrerer Abonnements zu einem (Gruppenfunktion)
+* Teilt sich mit Freunden, WG-Mitgliedern, Familie über die App
+|===
+
+---
+
+=== Persona 5: Felix Freelancer (Priorität 5)
+
+[cols="1,3"]
+|===
+| *Rolle*
+| 18–60 Jahre; technisches Niveau 7/10
+
+| *Fokus*
+| Ordnung & Steuer
+
+| *Ziele*
+a|
+* Unterscheidung Abo privat/geschäftlich (steuerlich absetzbar)
+
+| *Frustrationen*
+a|
+* Besitzt sowohl private Abos (Musik, Video) als auch geschäftliche Abos (Adobe, Shutterstock, Lizenz-Musik, …)
+* Kann diese nicht alle auseinanderhalten
+
+| *Bezug zum Produkt*
+a|
+* Automatisches Kategorisieren der Abomodelle in Domänenbereiche
+* Kann eigene Labels/Notizen hinzufügen
+|===
+
+---
+
+=== Weitere Personas (niedrige Priorität)
+
+[cols="1,1,1,1", options="header"]
+|===
+| Persona | Fokus | Hauptbedürfnis | Priorität
+
+| Sarah Mutter (ab 30 J.)
+| Haushaltsüberblick
+| Abos der Kinder mitverwalten; Notizen/Tags zu Abos anlegen
+| 2
+
+| Reiner Notech (ab 50 J.)
+| Einfachheit & Hilfe
+| Sehr einfache Oberfläche; Tutorial Guide durch App; anpassbares Frontend Design
+| 1
+|===
+
+NOTE: Für die Entwicklung liegt der Fokus auf Otto Normal (Prio 9), Thomas der Skeptische und Maximilian der Fortschrittliche (je Prio 7). Diese drei Personas decken die Kernnutzungsszenarien ab.
+
+---
 
 == Nutzungskontext
 
-_Der Nutzungskontext gemäß DIN EN ISO 9241-11 beschreibt die Lebenswirklichkeit der Personas — unabhängig vom Produkt. Er zeigt, in welchem Umfeld, mit welchen Mitteln und unter welchen Bedingungen das Produkt genutzt wird._
+_Der Nutzungskontext gemäß DIN EN ISO 9241-11 beschreibt die Lebenswirklichkeit der Personas — unabhängig vom Produkt._
 
 [cols="1,3", options="header"]
 |===
 | Aspekt | Beschreibung
- 
+
 | Benutzer
-| [Eigenschaften, Kenntnisse, Erfahrung, Motivation der Nutzenden.
-(Verweis auf Personas für ausführliche Beschreibungen)]
- 
+| Primär Studierende und junge Erwachsene (20–50 Jahre) mit mehreren aktiven digitalen Abonnements (Streaming, Gym, Lizenzen, Cloud-Dienste). Technisches Niveau variiert stark — von technikaffin (Maximilian, Prio 7) bis technisch wenig erfahren (Reiner, Prio 1). Schwerpunkt liegt auf der mittleren Gruppe (Otto Normal).
+
 | Ziele & Aufgaben
-| [Was wollen Nutzende erreichen?
-Welche konkreten Aufgaben führen sie dazu aus?]
- 
+a|
+* Schneller Überblick über alle aktiven Abos und Gesamtkosten
+* Kündigungsfristen im Blick behalten
+* Unnötige Abos erkennen und kündigen
+* Neue Abos erfassen (manuell oder automatisch)
+* Einsparpotenziale identifizieren
+
 | Ressourcen
-| [Hardware, Software, Eingabegeräte, Hilfsmittel, die zur Nutzung des Produkts benötigt werden oder vorhanden sind.]
- 
+a|
+* Primär Smartphones (iOS und Android)
+* Sekundär: Desktop-Browser (Laptop/PC)
+* Internetzugang (mobil und WLAN)
+* Keine Pflicht zur Bankverbindung
+
 | Umgebung
-| [Technische Umgebung: Netzwerk, Plattformen, Betriebssysteme, Interoperabilität.
-
- Physische Umgebung: Ort der Nutzung, Lichtverhältnisse, Lärm, Mobilität.
-
-Soziale & organisatorische Umgebung: Organisationsstruktur, Zusammenarbeit, Unterbrechungen, rechtliche oder regulatorische Rahmenbedingungen.]
- 
+a|
+* *Physisch*: Zu Hause auf dem Sofa, unterwegs, in der Hochschule — selten am Schreibtisch. Nutzung oft beiläufig, nicht fokussiert.
+* *Zeitlich*: Sporadisch — nicht täglich. Eher einmal im Monat beim „Finanzchecken" oder wenn eine Zahlung auffällt.
+* *Sozial*: Teils gemeinsame Nutzung mit WG-Mitgliedern oder Familienmitgliedern. Datenschutzbedenken bei sensiblen Finanzdaten.
+* *Technisch*: Verschiedene Plattformen und Betriebssysteme; wichtig ist Geräteunabhängigkeit.
 |===
 
 === Aktuelle Situation (ohne das Produkt)
 
-_Wie lösen die Nutzenden ihr Problem heute? Diese Beschreibung zeigt, was das Produkt
-verbessern soll — und macht den Mehrwert explizit._
-
-[Beschreibe den heutigen Ablauf in 3–5 Sätzen oder als kurze Schrittfolge. Beispiel: „Heute fragt Maria an der Infotheke nach freien Räumen, erhält eine Liste per E-Mail, und stellt beim Ankommen fest, dass der Raum bereits belegt ist.
-Der Prozess kostet sie im Schnitt 20 Minuten pro Tag."]
+Heute versuchen Nutzer, ihre Abos über Kontoauszüge, E-Mails oder Erinnerungen selbst im Blick zu behalten — ein zeitaufwändiger, fehleranfälliger Prozess.
+Abonnements werden vergessen, Kündigungsfristen verpasst, und Gesamtausgaben unterschätzt.
+Spezialisierte Tools existieren zwar (z. B. Finanzguru), sind aber entweder zu komplex, zu breit oder erfordern eine Bankverbindung.
 
 === Nutzungshürden & Risiken
-
-_Was könnte die Akzeptanz oder Nutzung des Produkts beeinträchtigen?_
 
 [cols="2,2", options="header"]
 |===
 | Hürde / Risiko | Mögliche Reaktion im Design
 
-| [z. B. Datenschutzbedenken bei Registrierungspflicht]
-| [z. B. Gastzugang für erste Nutzung anbieten]
+| Datenschutzbedenken bei Finanzdaten (insb. Thomas der Skeptische)
+| Kein Zwang zur Bankverbindung; Privacydashboard; lokale Datenspeicherung als Option; transparente Datenpolitik
 
-| [z. B. Schlechte WLAN-Verfügbarkeit in Gebäudeteilen]
-| [z. B. Offline-Ansicht für zuletzt geladene Daten]
+| Hoher Aufwand beim manuellen Erfassen von Abos (Otto Normal)
+| Automatische Erkennung aus E-Mails oder Bankdaten (optional); einfaches Erfassungsformular mit Autocomplete
 
-| [Weitere Hürde]
-| [Reaktion]
+| Zu viele Funktionen überfordern einfache Nutzer (Reiner Notech)
+| Klare, reduzierte Hauptansicht; optionale erweiterte Funktionen für Power User
+
+| Skepsis gegenüber digitalen Finanztools (Thomas)
+| Transparente Kommunikation; keine versteckten Datennutzungen; Vertrauensaufbau durch Bewertungen/Datenschutznachweise
+
+| Geteilte Abos in WGs führen zu Unübersichtlichkeit (Enrico)
+| Gruppenfunktion zum gemeinsamen Verwalten und Aufteilen von Abos
 |===
+
+---
 
 == Systemweite Interaktionsflüsse
 
-_Dieser Abschnitt beschreibt Abläufe, die mehrere Features oder Bereiche des Produkts
-umfassen. Einzelne Feature-Wireframes werden in den jeweiligen User Stories gepflegt.
-Hier dokumentieren wir nur Flüsse auf Systemebene, z.B. mit UML-Aktivitätsdiagrammen._
-
-=== [Flussname, z. B. Onboarding-Flow]
-
-_Beschreibe kurz, was dieser Fluss abdeckt und welche Personas er betrifft._
+=== Onboarding-Flow (Erstzugang)
 
 [plantuml, onboarding-flow, svg]
 ....
@@ -151,111 +304,70 @@ if (Bereits registriert?) then (ja)
   :Login;
 else (nein)
   :Registrierung;
-  :Bestätigungs-E-Mail;
-  :E-Mail bestätigen;
+  :Erstes Abo erfassen (optional);
 endif
-:Startseite;
+:Übersicht / Dashboard;
 stop
 
 @enduml
 ....
 
-[cols="1,1,2", options="header"]
-|===
-| Schritt | Beteiligte Persona | Anmerkung
+=== Kern-Flow: Abo erfassen und verwalten
 
-| App öffnen
-| Maria (Studierende)
-| Erster Einstiegspunkt; muss sofort orientieren
-
-| Login / Registrierung
-| Alle Personas
-| Registrierung nur beim ersten Besuch; danach automatischer Login
-
-| Startseite
-| Alle Personas
-| Zeigt direkt die wichtigste Funktion — keine unnötige Zwischenseite
-|===
-
----
-
-=== [Weiterer Fluss, z. B. Buchungsabbruch & Fehlerbehandlung]
-
-_Beschreibe den Fluss und ergänze ein Diagramm nach demselben Muster._
-
-[plantuml, error-flow, svg]
+[plantuml, abo-flow, svg]
 ....
 @startuml
 skinparam monochrome true
+skinparam defaultFontSize 13
 
 start
-:Buchung starten;
-if (Raum noch verfügbar?) then (ja)
-  :Buchung bestätigen;
-  :Bestätigung anzeigen;
+:Übersicht öffnen;
+:Liste aller Abos anzeigen;
+if (Neues Abo?) then (ja)
+  :Abo manuell erfassen\n(Name, Betrag, Intervall, Startdatum);
+  :Kategorie und Notizen hinzufügen (optional);
 else (nein)
-  :Fehlermeldung anzeigen;
-  :Alternative Räume vorschlagen;
+  :Bestehendes Abo auswählen;
+  :Details anzeigen / bearbeiten;
 endif
+if (Kündigen?) then (ja)
+  :Kündigungsweg wählen\n(direkt / Weiterleitung / Brief);
+else (nein)
+  :Erinnerung für Kündigungsfrist einstellen (optional);
+endif
+:Zurück zur Übersicht;
 stop
 
 @enduml
 ....
 
+---
+
 == Designsystem & Interaktionsprinzipien
 
-_Dieser Abschnitt dokumentiert systemweite Design- und Interaktionsentscheidungen,
-die konsistent über alle Features hinweg gelten. Sie bilden die Basis für alle
-Wireframes und UI-Implementierungen._
-
-=== Visuelle Sprache
-
-[cols="1,3", options="header"]
-|===
-| Aspekt | Entscheidung & Begründung
-
-| Farbpalette
-| [z. B. Primärfarbe: Hochschulblau #003D6E; Akzent: #E87722;
-  Begründung: Corporate Identity der Hochschule]
-
-| Typografie
-| [z. B. Fließtext: Inter 16px; Überschriften: Inter Bold;
-  Begründung: Hohe Lesbarkeit auf kleinen Bildschirmen]
-
-| Ikonografie
-| [z. B. Material Icons; konsistentes Icon-Set im gesamten Produkt]
-
-| Bildsprache
-| [z. B. Keine Stock-Fotos; Illustrationen im Flat-Design-Stil]
-|===
-
 === Interaktionsprinzipien
-
-_Vereinbarte UX-Regeln, die für das gesamte Produkt gelten. Jede Entscheidung
-wird begründet, damit sie nicht aus Unwissenheit verletzt wird._
 
 [cols="2,3", options="header"]
 |===
 | Prinzip | Beschreibung & Begründung
 
+| Einfachheit vor Vollständigkeit.
+| Die Kernfunktion (Abo erfassen und überblicken) muss ohne Einarbeitung nutzbar sein. Erweiterte Funktionen (Analysen, Datenschutzeinstellungen) sind zugänglich, aber nicht im Weg.
+
 | Destruktive Aktionen werden immer bestätigt.
-| Lösch- oder Stornieraktionen erfordern eine explizite Bestätigung durch die Nutzenden.
-  Verhindert unbeabsichtigte Datenverluste.
+| Lösch- oder Stornieraktionen (Abo löschen, Kündigung auslösen) erfordern eine explizite Bestätigung. Verhindert unbeabsichtigte Aktionen.
 
 | Leerzustände erklären sich und schlagen eine Aktion vor.
-| Wenn eine Liste leer ist, zeigen wir eine kurze Erklärung und einen Call-to-Action —
-  niemals nur eine leere Fläche. Reduziert Orientierungslosigkeit.
+| Wenn noch keine Abos erfasst sind, zeigen wir eine kurze Erklärung und einen Call-to-Action — niemals nur eine leere Fläche.
 
 | Fehlermeldungen sind verständlich und handlungsorientiert.
-| Fehlermeldungen nennen die Ursache in einfacher Sprache und schlagen einen
-  nächsten Schritt vor. Kein technischer Jargon für Endnutzer:innen.
+| Kein technischer Jargon; Fehlermeldungen nennen die Ursache und schlagen einen nächsten Schritt vor.
+
+| Datenschutz ist sichtbar und kontrollierbar.
+| Nutzer sehen jederzeit, welche Daten gespeichert werden. Datenschutzeinstellungen sind leicht zugänglich (nicht versteckt in tiefen Menüs).
 
 | Kernfunktionen sind mit einer Hand erreichbar.
-| Primäre Aktionen befinden sich im unteren Bildschirmbereich (Daumenzone).
-  Optimiert für einhändige Smartphone-Nutzung.
-
-| [Weiteres Prinzip]
-| [Beschreibung & Begründung]
+| Primäre Aktionen befinden sich im unteren Bildschirmbereich (Daumenzone). Optimiert für einhändige Smartphone-Nutzung.
 |===
 
 === Barrierefreiheit
@@ -267,22 +379,16 @@ wird begründet, damit sie nicht aus Unwissenheit verletzt wird._
 | Kontrastverhältnis
 | Mindestens WCAG 2.1 Level AA (Kontrast ≥ 4,5:1 für Fließtext)
 
-| Tastaturnavigation
-| Alle Kernfunktionen sind per Tastatur bedienbar
-
-| Screenreader
-| Alle interaktiven Elemente haben sinnvolle ARIA-Labels
-
 | Schriftgröße
 | Keine Schrift unter 14px; Nutzer:innen können Systemschriftgröße nutzen
 
-| [Weiterer Aspekt]
-| [Anforderung]
+| Tastaturnavigation
+| Alle Kernfunktionen sind per Tastatur bedienbar (Desktop)
+
+| Anpassbarkeit
+| Frontend-Design anpassbar (Anforderung aus Reiner Notech Persona)
 |===
 
+---
 
-_Dieses Dokument wird kontinuierlich weiterentwickelt — insbesondere nach Nutzerinterviews,
-Usability-Tests oder wesentlichen Designentscheidungen. Individuelle Feature-Wireframes
-werden nicht hier, sondern direkt in den User Stories im Product Backlog gepflegt._
-
-_Der Zweck dieses Dokuments ist es, die wesentlichen Bedarfe und Funktionalitäten des Systems {project-system-name} überblicksartig zu beschreiben. Der Fokus liegt auf den Fähigkeiten, die von Stakeholdern und adressierten Nutzern benötigt werden, und der Begründung dieser Bedarfe. Die Details, wie das System {project-system-name} diese Bedarfe erfüllt, werden durch User Stories im Product Backlog sowie dem UX-Konzept beschrieben._
+_Dieses Dokument wird kontinuierlich weiterentwickelt — insbesondere nach Nutzerinterviews, Usability-Tests oder wesentlichen Designentscheidungen. Individuelle Feature-Wireframes werden nicht hier, sondern direkt in den User Stories im Product Backlog gepflegt._


### PR DESCRIPTION
## What

Replaces the placeholder AsciiDoc templates under `docs/product/` with real content transferred from the Miro board.

## Changes

- `product_concept.adoc` — Motivation, Vision Statement, Stakeholder table (10 entries), 6 Hauptfunktionen with priority, 5 quality goals and 4 constraints
- `ux_concept.adoc` — All 7 personas (Otto Normal to Reiner Notech) with quotes, goals, frustrations and product relevance. Usage context per ISO 9241-11, usage barriers, two PlantUML flow diagrams and interaction principles
- `domain_glossary.adoc` — 25 domain terms with definitions and disambiguations, PlantUML domain model with entities and relationships

## Why

Closes the gap between our confirmed Miro artifacts and the formal project documentation required for the SE1 submission, before the sprint review with our stakeholders 

## Notes

Content reflects the state of the Miro board as of Sprint 1 review. PlantUML diagrams require `asciidoctor-diagram` to render.